### PR TITLE
Forecast serializer

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,32 +1,15 @@
 class Api::V1::ForecastController < ApplicationController
   def index
-    service = GoogleGeocodingService.new
-    coordinates = service.get_coordinates(params[:location])
-
-    darksky_service = DarkskyService.new(coordinates)
-    weather_data = darksky_service.weather_data
-    temp = weather_data["currently"]["temperature"]
-    high_temp = weather_data["daily"]["data"][0]["temperatureHigh"]
-    low_temp = weather_data["daily"]["data"][0]["temperatureLow"]
-    current_description = weather_data["currently"]["summary"]
-    feels_like = weather_data["currently"]["apparentTemperature"]
-    humidity = weather_data["currently"]["humidity"]
-    visibility = weather_data["currently"]["visibility"]
-    uv_index = weather_data["currently"]["uvIndex"]
-    day_description = weather_data["hourly"]["summary"]
-    night_description = weather_data["daily"]["summary"]
-    render json: {
-      "current_temperature" => temp,
-      "high_temp" => high_temp,
-      "low_temp" => low_temp,
-      "current_description" => current_description,
-      "feels_like" => feels_like,
-      "humidity" => humidity,
-      "visibility" => visibility,
-      "uv_index" => uv_index,
-      "day_description" => day_description,
-      "night_description" => night_description
-    }
-    # /maps/api/geocode/json?address=1600+Amphitheatre+Parkway,+Mountain+View,+CA&key=YOUR_API_KEY"
+    binding.pry
+    forecast = ForecastGenerator.new(forecast_params).generate
+    serialized = ForecastSerializer.new(forecast).serialized_json
+    binding.pry
+    render json: forecast
   end
+
+  private
+
+    def forecast_params
+      params.permit(:location)
+    end
 end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,0 +1,14 @@
+class ForecastSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :current_temperature,
+                :high_temperature,
+                :low_temperature,
+                :current_description,
+                :feels_like,
+                :humidity,
+                :visibility,
+                :uv_index,
+                :day_description,
+                :night_description,
+                :weekly_forecast
+end

--- a/spec/requests/api/v1/weather_request_spec.rb
+++ b/spec/requests/api/v1/weather_request_spec.rb
@@ -8,7 +8,6 @@ describe 'Weather API' do
     expect(response).to be_successful
 
     weather_data = JSON.parse(response.body)
-    binding.pry
     expect(weather_data.keys).to contain_exactly('data')
     expect(weather_data["data"].keys).to contain_exactly('id',
                                                          'type',


### PR DESCRIPTION
* Adds fast_json serializer for Forecast
* Renders this serialized version of forecast in the forecast controller
* Changes the request spec to account for the serialized version of this data